### PR TITLE
Fix 'make install': create the target directory and install the jar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,17 @@ modelica_java.jar: $(java_sources)
 	"$(JAVAC)" -encoding utf8 -cp "$(antlr)$(sep)$(corba)" -d bin-jar $(java_sources)
 	"$(JAR)" cf modelica_java.jar $(java_sources:src/%=-C src %) $(resources:src/%=-C src %) -C bin-jar . || (rm $@ && false)
 	
-install: ../build/share/omc/java/modelica_java.jar
+# OMJava used to be built inside the OpenModelica source tree, so the default
+# keeps that layout. It is no longer part of the OpenModelica distribution;
+# point OMBUILDDIR at an OpenModelica installation to install into one.
+OMBUILDDIR ?= ../build
+javadir = $(OMBUILDDIR)/share/omc/java
 
-../build/share/omc/java/modelica_java.jar: modelica_java.jar
-	cp 3rdParty/*.jar ../build/share/omc/java/
+install: $(javadir)/modelica_java.jar
+
+$(javadir)/modelica_java.jar: modelica_java.jar
+	mkdir -p $(@D)
+	cp modelica_java.jar 3rdParty/*.jar $(licenses) $(@D)/
 	
 test: $(java_sources) 
 	rm -rf bin-test; mkdir bin-test


### PR DESCRIPTION
`make install` has been broken in two ways since "resurect OMJava" (34b6104, 2020). This fixes both so the repository is usable on its own.

Related: OpenModelica/OpenModelicaSetup#83 removes OMJava from the OpenModelica Windows release. This PR is not a prerequisite for that one — it makes OMJava work standalone, which is how it is used from now on.

## 1. The target directory is never created

```make
../build/share/omc/java/modelica_java.jar: modelica_java.jar
	cp 3rdParty/*.jar ../build/share/omc/java/
```

This worked by accident: OMJava was cloned into an OpenModelica source tree whose autotools build created `<build>/share/omc/java` as part of its own install-dirs list. That is no longer the case, and the copy fails:

```
cp 3rdParty/*.jar ../build/share/omc/java/
cp: target '../build/share/omc/java/' is not a directory
make: *** [Makefile:16: ../build/share/omc/java/modelica_java.jar] Error 1
```

## 2. `modelica_java.jar` is never installed

The recipe copies `3rdParty/*.jar`, but the client jar is built at the repository root and was never in the copy list — despite being the file the target names. So the rule:

- left its own target missing, and therefore re-ran on every `make install`;
- installed the client's *dependencies* (jacorb, slf4j, junit, …) without the client itself.

Every OpenModelica release since 2020 has shipped that partial set.

## The fix

```make
OMBUILDDIR ?= ../build
javadir = $(OMBUILDDIR)/share/omc/java

install: $(javadir)/modelica_java.jar

$(javadir)/modelica_java.jar: modelica_java.jar
	mkdir -p $(@D)
	cp modelica_java.jar 3rdParty/*.jar $(licenses) $(@D)/
```

`mkdir -p` plus the missing `modelica_java.jar`, and the antlr license that ships with it.

`OMBUILDDIR` is the one addition beyond the two bugs: now that OMJava is built outside the OpenModelica tree, the destination is no longer necessarily a sibling directory. It defaults to the previous `../build`, so existing usage is unchanged — happy to drop it if you would rather keep the path fixed.

## Verification

With JDK 21, against a real `make dep` checkout:

| | result |
| --- | --- |
| `make install` into an empty `../build` | succeeds; `modelica_java.jar` installed |
| `make install` again | `make: Nothing to be done for 'install'.` |
| `make install OMBUILDDIR=<elsewhere>` | installs into that tree |
| `make build` | unaffected |

And on unpatched master, for comparison:

| | result |
| --- | --- |
| `make install` into an empty `../build` | the `cp` failure above |
| `make install` with the directory pre-created | exits 0, and `modelica_java.jar` is **not** installed |

---
generated by Claude Code
